### PR TITLE
Post analysis reweighting resolution

### DIFF
--- a/postanalysis/__init__.py
+++ b/postanalysis/__init__.py
@@ -1,0 +1,9 @@
+'''
+Function(s) for the postanalysis toolkit
+'''
+
+import logging
+log = logging.getLogger(__name__)
+
+import _stats
+from _stats import (stats_process) #@UnresolvedImport

--- a/postanalysis/_stats.pyx
+++ b/postanalysis/_stats.pyx
@@ -1,0 +1,82 @@
+# Copyright (C) 2013 Matthew C. Zwier and Lillian T. Chong
+#
+# This file is part of WESTPA.
+#
+# WESTPA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# WESTPA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with WESTPA.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import print_function,division
+import cython
+import numpy
+import warnings
+cimport numpy
+
+ctypedef numpy.uint16_t index_t
+ctypedef numpy.float64_t weight_t
+ctypedef numpy.uint8_t bool_t
+ctypedef numpy.int64_t seg_id_t
+ctypedef numpy.uint_t uint_t # 32 bits on 32-bit systems, 64 bits on 64-bit systems
+
+cdef double NAN = numpy.nan 
+
+weight_dtype = numpy.float64  
+index_dtype = numpy.uint16
+bool_dtype = numpy.bool_
+
+from westpa.binning.assign import UNKNOWN_INDEX as _UNKNOWN_INDEX
+cdef index_t UNKNOWN_INDEX = _UNKNOWN_INDEX  
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef flux_assign(numpy.ndarray[weight_t, ndim=1] weights,
+                  numpy.ndarray[index_t, ndim=1] init_assignments,
+                  numpy.ndarray[index_t, ndim=1] final_assignments,
+                  numpy.ndarray[weight_t, ndim=2] flux_matrix):
+    cdef:
+        Py_ssize_t m,n
+        index_t i, j
+    n = len(weights)
+    for m from 0 <= m < n:
+        i = init_assignments[m]
+        j = final_assignments[m]
+        flux_matrix[i,j] += weights[m]
+    return
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef stats_process(numpy.ndarray[index_t, ndim=2] bin_assignments,
+                    numpy.ndarray[weight_t, ndim=1] weights, 
+                    numpy.ndarray[weight_t, ndim=1] fluxes, 
+                    numpy.ndarray[weight_t, ndim=1] populations, 
+                    numpy.ndarray[index_t, ndim=1] trans, 
+                    numpy.ndarray[index_t, ndim=2] mask):
+    cdef:
+        Py_ssize_t i,k
+        index_t ibin,fbin,nsegs,npts
+    nsegs = bin_assignments.shape[0]
+    npts = bin_assignments.shape[1]
+
+    for i in xrange(0,npts - 1):
+        for k in xrange(nsegs):
+            ibin = bin_assignments[k,i]
+            fbin = bin_assignments[k, i + 1]
+
+            if mask[k, 0] == 1:
+                continue
+
+            w = weights[k]
+
+            fluxes[ibin, fbin] += w
+            trans[ibin, fbin] += 1
+            populations[ibin] += w
+    return

--- a/postanalysis/_stats.pyx
+++ b/postanalysis/_stats.pyx
@@ -15,6 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with WESTPA.  If not, see <http://www.gnu.org/licenses/>.
 
+# A cythoned version of the original function of the stats_process function,
+# based on _kinetics.pyx
+
 from __future__ import print_function,division
 import cython
 import numpy
@@ -27,30 +30,9 @@ ctypedef numpy.uint8_t bool_t
 ctypedef numpy.int64_t trans_t
 ctypedef numpy.uint_t uint_t # 32 bits on 32-bit systems, 64 bits on 64-bit systems
 
-cdef double NAN = numpy.nan 
-
 weight_dtype = numpy.float64  
 index_dtype = numpy.uint16
 bool_dtype = numpy.bool_
-
-from westpa.binning.assign import UNKNOWN_INDEX as _UNKNOWN_INDEX
-cdef index_t UNKNOWN_INDEX = _UNKNOWN_INDEX  
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cpdef flux_assign(numpy.ndarray[weight_t, ndim=1] weights,
-                  numpy.ndarray[index_t, ndim=1] init_assignments,
-                  numpy.ndarray[index_t, ndim=1] final_assignments,
-                  numpy.ndarray[weight_t, ndim=2] flux_matrix):
-    cdef:
-        Py_ssize_t m,n
-        index_t i, j
-    n = len(weights)
-    for m from 0 <= m < n:
-        i = init_assignments[m]
-        j = final_assignments[m]
-        flux_matrix[i,j] += weights[m]
-    return
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/postanalysis/_stats.pyx
+++ b/postanalysis/_stats.pyx
@@ -24,7 +24,7 @@ cimport numpy
 ctypedef numpy.uint16_t index_t
 ctypedef numpy.float64_t weight_t
 ctypedef numpy.uint8_t bool_t
-ctypedef numpy.int64_t seg_id_t
+ctypedef numpy.int64_t trans_t
 ctypedef numpy.uint_t uint_t # 32 bits on 32-bit systems, 64 bits on 64-bit systems
 
 cdef double NAN = numpy.nan 
@@ -56,9 +56,9 @@ cpdef flux_assign(numpy.ndarray[weight_t, ndim=1] weights,
 @cython.wraparound(False)
 cpdef stats_process(numpy.ndarray[index_t, ndim=2] bin_assignments,
                     numpy.ndarray[weight_t, ndim=1] weights, 
-                    numpy.ndarray[weight_t, ndim=1] fluxes, 
+                    numpy.ndarray[weight_t, ndim=2] fluxes, 
                     numpy.ndarray[weight_t, ndim=1] populations, 
-                    numpy.ndarray[index_t, ndim=1] trans, 
+                    numpy.ndarray[trans_t, ndim=2] trans, 
                     numpy.ndarray[index_t, ndim=2] mask):
     cdef:
         Py_ssize_t i,k

--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,9 @@ setup(cmdclass = cmdclass,
                      Extension("westpa.kinetics._kinetics",
                                 ["westpa/kinetics/_kinetics.{}".format(suffix)],
                                 include_dirs=['.', numpy_include],
+                                extra_compile_args=['-O3']),
+                     Extension("postanalysis._stats",
+                                ["postanalysis/_stats.{}".format(suffix)],
+                                include_dirs=['.', numpy_include],
                                 extra_compile_args=['-O3']),])
 

--- a/w_postanalysis_matrix.py
+++ b/w_postanalysis_matrix.py
@@ -12,7 +12,7 @@ from west.data_manager import seg_id_dtype
 from westpa.binning import index_dtype
 from westtools import (WESTTool, WESTDataReader, IterRangeSelection,
                        ProgressIndicatorComponent)
-from postanalysis.stats import stats_process
+from postanalysis import stats_process
 
 log = logging.getLogger('westtools.w_postanalysis_matrix')
 

--- a/w_postanalysis_matrix.py
+++ b/w_postanalysis_matrix.py
@@ -158,28 +158,9 @@ either equilibrium or steady-state conditions without recycling target states.
 
                 pi.progress += 1
 
-            # Check for the number of intermediate time points; this will be used to normalize the
+            # Check and save the number of intermediate time points; this will be used to normalize the
             # flux and kinetics to tau in w_postanalysis_reweight.
             self.output_file.attrs['npts'] = npts
-
-
-def old_stats_process(bin_assignments, weights, fluxes, populations, trans, mask):
-    nsegs = bin_assignments.shape[0]
-    npts = bin_assignments.shape[1]
-
-    for k in xrange(nsegs):
-        ibin = bin_assignments[k,0]
-        fbin = bin_assignments[k, npts - 1]
-
-        if mask[k, 0] == 1:
-            continue
-
-        w = weights[k]
-
-        fluxes[ibin, fbin] += w
-        trans[ibin, fbin] += 1
-        populations[ibin] += w
-
 
 def calc_stats(bin_assignments, weights, fluxes, populations, trans, mask):
     fluxes.fill(0.0)

--- a/w_postanalysis_matrix.py
+++ b/w_postanalysis_matrix.py
@@ -12,6 +12,7 @@ from west.data_manager import seg_id_dtype
 from westpa.binning import index_dtype
 from westtools import (WESTTool, WESTDataReader, IterRangeSelection,
                        ProgressIndicatorComponent)
+from postanalysis.stats import stats_process
 
 log = logging.getLogger('westtools.w_postanalysis_matrix')
 
@@ -113,17 +114,6 @@ either equilibrium or steady-state conditions without recycling target states.
                 nsegs, npts = iter_group['pcoord'].shape[0:2] 
                 weights = seg_index['weight']
 
-                # Check to make sure there aren't intermediate time points saved, since this invalidates
-                # the analysis. 
-                if npts > 2:
-                    err_msg = '''\
-The post-analysis reweighting method requires assignments calculated from only
-the initial and final time points for each trajectory segment. If you are using
-an assignment file generated from a subsampled h5 file, please ensure that you 
-specify the -W flag so that w_postanalysis_matrix extracts data from matching
-assignment and WEST data files.
-'''
-                    raise ValueError(err_msg)
 
                 # Get bin and traj. ensemble assignments from the previously-generated assignments file
                 assignment_iiter = h5io.get_iteration_entry(self.assignments_file, n_iter)
@@ -168,8 +158,12 @@ assignment and WEST data files.
 
                 pi.progress += 1
 
+            # Check for the number of intermediate time points; this will be used to normalize the
+            # flux and kinetics to tau in w_postanalysis_reweight.
+            self.output_file.attrs['npts'] = npts
 
-def stats_process(bin_assignments, weights, fluxes, populations, trans, mask):
+
+def old_stats_process(bin_assignments, weights, fluxes, populations, trans, mask):
     nsegs = bin_assignments.shape[0]
     npts = bin_assignments.shape[1]
 

--- a/w_postanalysis_reweight.py
+++ b/w_postanalysis_reweight.py
@@ -286,6 +286,7 @@ Command-line options
             state_labels = self.assignments_file['state_labels'][...]
             state_map = self.assignments_file['state_map'][...]
             nfbins = self.kinetics_file.attrs['nrows']
+            npts = self.kinetics_file.attrs['npts']
 
             assert nstates == len(state_labels)
             assert nfbins == nbins * nstates
@@ -317,7 +318,8 @@ Command-line options
                     rw_state_flux, rw_color_probs, rw_state_probs, rw_bin_probs, rw_bin_flux = reweight(**params)
                     for k in xrange(nstates):
                         for j in xrange(nstates):
-                            flux_evol[iblock]['expected'][k,j] = rw_state_flux[k,j]
+                            # Normalize such that we report the flux per tau (tau being the weighted ensemble iteration)
+                            flux_evol[iblock]['expected'][k,j] = rw_state_flux[k,j] * npts
                             flux_evol[iblock]['iter_start'][k,j] = start
                             flux_evol[iblock]['iter_stop'][k,j] = stop
 
@@ -345,7 +347,8 @@ Command-line options
                     rw_state_flux, rw_color_probs, rw_state_probs, rw_bin_probs, rw_bin_flux = reweight(**params)
                     for k in xrange(nstates):
                         for j in xrange(nstates):
-                            flux_evol[iblock]['expected'][k,j] = rw_state_flux[k,j]
+                            # Normalize such that we report the flux per tau (tau being the weighted ensemble iteration)
+                            flux_evol[iblock]['expected'][k,j] = rw_state_flux[k,j] * npts
                             flux_evol[iblock]['iter_start'][k,j] = start
                             flux_evol[iblock]['iter_stop'][k,j] = stop
 

--- a/w_postanalysis_reweight.py
+++ b/w_postanalysis_reweight.py
@@ -319,7 +319,8 @@ Command-line options
                     for k in xrange(nstates):
                         for j in xrange(nstates):
                             # Normalize such that we report the flux per tau (tau being the weighted ensemble iteration)
-                            flux_evol[iblock]['expected'][k,j] = rw_state_flux[k,j] * npts
+                            # npts always includes a 0th time point
+                            flux_evol[iblock]['expected'][k,j] = rw_state_flux[k,j] * (npts - 1)
                             flux_evol[iblock]['iter_start'][k,j] = start
                             flux_evol[iblock]['iter_stop'][k,j] = stop
 
@@ -348,7 +349,8 @@ Command-line options
                     for k in xrange(nstates):
                         for j in xrange(nstates):
                             # Normalize such that we report the flux per tau (tau being the weighted ensemble iteration)
-                            flux_evol[iblock]['expected'][k,j] = rw_state_flux[k,j] * npts
+                            # npts always includes a 0th time point
+                            flux_evol[iblock]['expected'][k,j] = rw_state_flux[k,j] * (npts - 1)
                             flux_evol[iblock]['iter_start'][k,j] = start
                             flux_evol[iblock]['iter_stop'][k,j] = stop
 


### PR DESCRIPTION
Alright, I think I did this correctly.  This should merge the full resolution branch into @synapticarbors' original reweighting branch.  The modifications are fast, accurate, and work with any time resolution that w_assign sends in, and the results are given in units of per tau.  You only need to ensure that the correct cython modules are built (i.e., that the setup.py is run).