### PR TITLE
fix yamlcfg get_typed()

### DIFF
--- a/westpa/yamlcfg.py
+++ b/westpa/yamlcfg.py
@@ -227,7 +227,7 @@ class YAMLConfig:
         if type_ is bool and not isinstance(item, bool):
             warn_dubious_config_entry(key, item, bool)
             
-        return type(item)
+        return type_(item)
     
     def get_path(self, key, default=NotProvided, expandvars = True, expanduser = True, realpath = True, abspath = True):
         try:


### PR DESCRIPTION
Was randomly looking through the code and noticed, what I think is, a bug in the `get_typed` method of the yamlcfg module. The method is not used anywhere in the code, so this shouldn't effect anything.

Can someone do a quick review of this and then merge it?