### PR TITLE
Yaml branch - with limited namespace code execution

### DIFF
--- a/tests/testyamlfe.py
+++ b/tests/testyamlfe.py
@@ -50,9 +50,14 @@ class TESTSystem(ycf.YAMLSystem):
 # A class to test both paths at the same time
 # if it works we assure we can load the driver
 # AND overwrite it properly
-class TestYAMLFrontEndDriver:
+class TestYAMLFrontEnd:
     
-    def __init__(self):
+    def testYAMLFEDriver(self):
+        '''
+        Test method to ensure the YAML system generator works as
+        advertised
+        '''
+
         # First the objects that will be used for testing
         rc = westpa.rc
         yamlConf = ycf.YAMLConfig()    
@@ -72,12 +77,6 @@ class TestYAMLFrontEndDriver:
         rc.config = yamlConf
 
         self.system = rc.new_system_driver()
-
-    def testYAMLFE(self):
-        '''
-        Test method to ensure the YAML system generator works as
-        advertised
-        '''
        
         system = self.system
         # Assert we have the right options
@@ -92,12 +91,7 @@ class TestYAMLFrontEndDriver:
         ## These should be the same as the original
         assert system.test_variable_2 == "And I'm the second one"
 
-# Now one with only the YAML config file
-# This ensures we can get the system off of 
-# the yaml file only
-class TestYAMLFrontEndConfig:
-    
-    def __init__(self):
+    def testYAMLFEConfig(self):
         # First the objects that will be used for testing
         rc = westpa.rc
         yamlConf = ycf.YAMLConfig()    
@@ -117,11 +111,6 @@ class TestYAMLFrontEndConfig:
 
         self.system = rc.new_system_driver()
 
-    def testYAMLFE(self):
-        '''
-        Test method to ensure the YAML system generator works as
-        advertised
-        '''
         system = self.system
         # Assert we have the right options
         # This needs some more documentation and alerts for the assertions

--- a/tests/testyamlfe.py
+++ b/tests/testyamlfe.py
@@ -50,14 +50,9 @@ class TESTSystem(ycf.YAMLSystem):
 # A class to test both paths at the same time
 # if it works we assure we can load the driver
 # AND overwrite it properly
-class TestYAMLFrontEnd:
+class TestYAMLFrontEndDriver:
     
-    def testYAMLFEDriver(self):
-        '''
-        Test method to ensure the YAML system generator works as
-        advertised
-        '''
-
+    def __init__(self):
         # First the objects that will be used for testing
         rc = westpa.rc
         yamlConf = ycf.YAMLConfig()    
@@ -77,6 +72,12 @@ class TestYAMLFrontEnd:
         rc.config = yamlConf
 
         self.system = rc.new_system_driver()
+
+    def testYAMLFE(self):
+        '''
+        Test method to ensure the YAML system generator works as
+        advertised
+        '''
        
         system = self.system
         # Assert we have the right options
@@ -91,7 +92,12 @@ class TestYAMLFrontEnd:
         ## These should be the same as the original
         assert system.test_variable_2 == "And I'm the second one"
 
-    def testYAMLFEConfig(self):
+# Now one with only the YAML config file
+# This ensures we can get the system off of 
+# the yaml file only
+class TestYAMLFrontEndConfig:
+    
+    def __init__(self):
         # First the objects that will be used for testing
         rc = westpa.rc
         yamlConf = ycf.YAMLConfig()    
@@ -104,13 +110,18 @@ class TestYAMLFrontEnd:
                            "bin_target_counts": 10,
                              "bins": {
                                "type":"RectilinearBinMapper", 
-                                 "boundaries": [[0.0, 0.5, 1.5, 2.5, 3.5, 'inf']]
+                                 "boundaries": ["numpy.arange(0.0, 5.0, 0.5)"]
                                  }}}}}
         yamlConf._data = test_dict
         rc.config = yamlConf
 
         self.system = rc.new_system_driver()
 
+    def testYAMLFE(self):
+        '''
+        Test method to ensure the YAML system generator works as
+        advertised
+        '''
         system = self.system
         # Assert we have the right options
         # This needs some more documentation and alerts for the assertions
@@ -118,6 +129,6 @@ class TestYAMLFrontEnd:
         assert system.test_variable == "I'm a test variable"
         # This one in particular checks if the bins are passed correctly
         assert (system.bin_mapper.boundaries == \
-               numpy.array([[0.0, 0.5, 1.5, 2.5, 3.5, 'inf']], dtype=numpy.float32)).all()
+               numpy.arange(0.0, 5.0, 0.5)).all()
         assert system.pcoord_len == 10
         assert system.pcoord_dtype == numpy.float32

--- a/westpa/_rc.py
+++ b/westpa/_rc.py
@@ -45,7 +45,7 @@ def bins_from_yaml_dict(bin_dict):
         parsed_lists = boundary_lists[:]
         for iboundary, boundary in enumerate(boundary_lists):
             if boundary.__class__ == str:
-                parsed_lists[iboundary] = list(parsePCV(boundary)[0])
+                parsed_lists[iboundary] = parsePCV(boundary)[0]
             else: 
                 parsed_lists[iboundary] = map((lambda x: float('inf') if (x if isinstance(x, basestring) else '').lower() == 'inf' else x), boundary)
         return mapper_type(parsed_lists)

--- a/westpa/_rc.py
+++ b/westpa/_rc.py
@@ -42,18 +42,13 @@ def bins_from_yaml_dict(bin_dict):
     
     if typename == 'RectilinearBinMapper':
         boundary_lists = kwargs.pop('boundaries')
-        if boundary_lists[0].__class__ == str and len(boundary_lists) == 1:
-            # The idea here is that if I have a single point I can't be a boundary list
-            # and I also can't be a string if I'm a boundary thus I can now assume that
-            # the boundary given is actually a code and run the parser on the code instead.
-            boundary_lists = parsePCV(boundary_lists[0])
-        else:
-            for ilist, boundaries in enumerate(boundary_lists):
-                boundary_lists[ilist] = map((lambda x: 
-                                               float('inf') 
-                                               if (x if isinstance(x, basestring) else '').lower() == 'inf' 
-                                               else x), boundaries)
-        return mapper_type(boundary_lists)
+        parsed_lists = boundary_lists[:]
+        for iboundary, boundary in enumerate(boundary_lists):
+            if boundary.__class__ == str:
+                parsed_lists[iboundary] = list(parsePCV(boundary)[0])
+            else: 
+                parsed_lists[iboundary] = map((lambda x: float('inf') if (x if isinstance(x, basestring) else '').lower() == 'inf' else x), boundary)
+        return mapper_type(parsed_lists)
     else:
         try:
             return mapper_type(**kwargs)
@@ -76,7 +71,8 @@ def parsePCV(pc_str):
         arr.shape = (1,) + arr.shape 
     else:
         raise ValueError('too many dimensions')
-    return arr
+    #return list(arr[...])
+    return arr[...]
 
 def lazy_loaded(backing_name, loader, docstring = None):
     def getter(self):

--- a/westpa/_rc.py
+++ b/westpa/_rc.py
@@ -22,7 +22,7 @@ from __future__ import division, print_function; __metaclass__ = type
 import logging
 log = logging.getLogger('westpa.rc')
 
-import os, sys, errno, numpy
+import os, sys, errno, numpy, math
 import westpa
 from yamlcfg import YAMLConfig
 from yamlcfg import YAMLSystem
@@ -42,11 +42,14 @@ def bins_from_yaml_dict(bin_dict):
     
     if typename == 'RectilinearBinMapper':
         boundary_lists = kwargs.pop('boundaries')
-        for ilist, boundaries in enumerate(boundary_lists):
-            boundary_lists[ilist] = map((lambda x: 
-                                           float('inf') 
-                                           if (x if isinstance(x, basestring) else '').lower() == 'inf' 
-                                           else x), boundaries)
+        if boundary_lists[0].__class__ == str and len(boundary_lists) == 1:
+            boundary_lists = parsePCV(boundary_lists[0])
+        else:
+            for ilist, boundaries in enumerate(boundary_lists):
+                boundary_lists[ilist] = map((lambda x: 
+                                               float('inf') 
+                                               if (x if isinstance(x, basestring) else '').lower() == 'inf' 
+                                               else x), boundaries)
         return mapper_type(boundary_lists)
     else:
         try:
@@ -67,7 +70,8 @@ def parsePCV(pc_str):
         arr.shape = (1,) + arr.shape 
     else:
         raise ValueError('too many dimensions')
-    return arr
+    #return list(arr[...])
+    return arr[...]
 
 def lazy_loaded(backing_name, loader, docstring = None):
     def getter(self):

--- a/westpa/_rc.py
+++ b/westpa/_rc.py
@@ -42,7 +42,10 @@ def bins_from_yaml_dict(bin_dict):
     
     if typename == 'RectilinearBinMapper':
         boundary_lists = kwargs.pop('boundaries')
-        if boundary_lists[0].__class__ == str and len(boundary_lists) == 1:
+        if isinstance(boundary_lists[0], basestring) and len(boundary_lists) == 1:
+            # The idea here is that if I have a single point I can't be a boundary list
+            # and I also can't be a string if I'm a boundary thus I can now assume that
+            # the boundary given is actually a code and run the parser on the code instead.
             boundary_lists = parsePCV(boundary_lists[0])
         else:
             for ilist, boundaries in enumerate(boundary_lists):
@@ -59,6 +62,9 @@ def bins_from_yaml_dict(bin_dict):
             raise
 
 def parsePCV(pc_str):
+    # Execute arbitrary code within a limited
+    # scope to avoid nastyness. Stolen fully from 
+    # other parts of the WESTPA code. 
     namespace = {'math': math,
                  'numpy': numpy,
                  'inf': float('inf')}

--- a/westpa/_rc.py
+++ b/westpa/_rc.py
@@ -76,8 +76,7 @@ def parsePCV(pc_str):
         arr.shape = (1,) + arr.shape 
     else:
         raise ValueError('too many dimensions')
-    #return list(arr[...])
-    return arr[...]
+    return arr
 
 def lazy_loaded(backing_name, loader, docstring = None):
     def getter(self):

--- a/westpa/_rc.py
+++ b/westpa/_rc.py
@@ -42,7 +42,7 @@ def bins_from_yaml_dict(bin_dict):
     
     if typename == 'RectilinearBinMapper':
         boundary_lists = kwargs.pop('boundaries')
-        if isinstance(boundary_lists[0], basestring) and len(boundary_lists) == 1:
+        if boundary_lists[0].__class__ == str and len(boundary_lists) == 1:
             # The idea here is that if I have a single point I can't be a boundary list
             # and I also can't be a string if I'm a boundary thus I can now assume that
             # the boundary given is actually a code and run the parser on the code instead.


### PR DESCRIPTION
Hi all, 

I meant to push this ages ago but I'm glad I waited since I updated this a bit and it's a lot better I think. I had the parsePCV function in the code already (directly copied from other parts of the code that deals with the bins specification for the tools) with the intention of adding this and now it's working. The code passed the test I wrote and I played around a bit with the west.cfg to see if it easily breaks and it seems to work fine.

The idea is to loop over the boundary lists provided for each dimension, if it's a string assume it's code and execute the code in a limited namespace, take the result and use it in the boundary list for that dimension. This allows you to do stuff like the following in the config file:

      bins:
        type: RectilinearBinMapper
        boundaries:
          - "[i for i in range(3)]+[float('inf')]"
          - [0.0, 1.0, 2.0, inf]
          - "numpy.arange(0.0, 12.0, 3)"
          - "[0.0, 1.0, 2.0, float('inf')]"

I'll be making a short guide on how to use this front end soon.